### PR TITLE
Stahovani originalu jpeg2000

### DIFF
--- a/imageserver/default/docker-compose.yml
+++ b/imageserver/default/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   nginx:
-    #build: ./nginx
+    build: ./nginx
     image: moravianlibrary/iipsrv-nginx:latest
     environment:
       - "TZ=Europe/Prague"

--- a/imageserver/default/nginx/nginx.conf
+++ b/imageserver/default/nginx/nginx.conf
@@ -10,6 +10,11 @@ server {
         fastcgi_pass iipimage:9000;
         fastcgi_intercept_errors on;
     }
+
+    location /download/ {
+        alias /var/www/imageserver/data/;
+        try_files $uri $uri.jp2 =404;
+    }
     
     location / {
         #MZK predefined suffixes
@@ -33,5 +38,8 @@ server {
         #iiif info request (json/xml)
         rewrite ^([a-zA-Z0-9_\/\.\-]*)\/info.json$ /iipsrv.fcgi?iiif=$1.jp2/info.json last;
         rewrite ^([a-zA-Z0-9_\/\.\-]*)\/info.xml$ /iipsrv.fcgi?iiif=$1.jp2/info.xml last;
+        
+        #download original image
+        rewrite ^([a-zA-Z0-9_\/\.\-]*)\/original$ /download/$1 last;
     }
 }


### PR DESCRIPTION
Bylo to nastavene pouze pro mzk variantu, potrebuji to i pro default tag.

Krome toho jsem si vsiml, ze nejde zbuildit iipimage obraz - chybi mu debiani balicek ke kopii - to je schvalne?