### PR TITLE
Library load fix

### DIFF
--- a/solr6/Dockerfile
+++ b/solr6/Dockerfile
@@ -3,8 +3,10 @@ FROM solr:6.3.0-alpine
 MAINTAINER Martin Rumanek <martin@rumanek.cz>
 
 USER root
+RUN apk add --no-cache subversion
+RUN svn export https://github.com/ceskaexpedice/kramerius/branches/oai4solr6/installation/oai4solr6/lib/ \
+    /opt/solr/server/solr/lib/ --force
 ADD kramerius /kramerius
-ADD lib /opt/solr/server/solr/lib
 ADD oai/ /opt/solr/server/solr/oai
 
 RUN chown -R $SOLR_USER:$SOLR_USER /kramerius


### PR DESCRIPTION
Stahuje knihovnu z [oai4solr6](https://github.com/ceskaexpedice/kramerius/tree/oai4solr6/installation/oai4solr6), otestovano na lokalu.